### PR TITLE
Migrate Intercode infrastructure to Intercode-vended modules

### DIFF
--- a/concentral.net.tf
+++ b/concentral.net.tf
@@ -101,31 +101,31 @@ module "concentral_net_forwardemail_receiving_domain" {
 
   cloudflare_zone   = cloudflare_zone.concentral_net
   name              = "concentral.net"
-  verification_code = local.forwardemail_verification_records_by_domain["concentral.net"]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain["concentral.net"]
 }
 
 module "concentral_net_convention_mx_forwardemail_receiving_domain" {
   for_each = setintersection(
-    keys(local.forwardemail_verification_records_by_domain),
+    keys(module.forwardemail_receiving.verification_records_by_domain),
     [for subdomain in local.concentral_net_convention_mx_subdomains : "${subdomain}.concentral.net"]
   )
   source = "github.com/neinteractiveliterature/neil-terraform-modules//forwardemail_receiving_domain?ref=v1.0.0"
 
   cloudflare_zone   = cloudflare_zone.concentral_net
   name              = each.value
-  verification_code = local.forwardemail_verification_records_by_domain[each.value]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain[each.value]
 }
 
 module "concentral_net_convention_mx_events_forwardemail_receiving_domain" {
   for_each = setintersection(
-    keys(local.forwardemail_verification_records_by_domain),
+    keys(module.forwardemail_receiving.verification_records_by_domain),
     [for subdomain in local.concentral_net_convention_mx_subdomains : "events.${subdomain}.concentral.net"]
   )
   source = "github.com/neinteractiveliterature/neil-terraform-modules//forwardemail_receiving_domain?ref=v1.0.0"
 
   cloudflare_zone   = cloudflare_zone.concentral_net
   name              = each.value
-  verification_code = local.forwardemail_verification_records_by_domain[each.value]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain[each.value]
 }
 
 # Having an MX record breaks the wildcard CNAME, so we have to have a specific A record for each MX domain

--- a/extraconlarp.org.tf
+++ b/extraconlarp.org.tf
@@ -84,7 +84,7 @@ module "extraconlarp_org_convention_subdomain_forwardemail_receiving_domain" {
 
   cloudflare_zone   = cloudflare_zone.extraconlarp_org
   name              = each.value
-  verification_code = local.forwardemail_verification_records_by_domain[each.value]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain[each.value]
 }
 
 module "extraconlarp_org_convention_subdomain_2021_events_forwardemail_receiving_domain" {
@@ -92,7 +92,7 @@ module "extraconlarp_org_convention_subdomain_2021_events_forwardemail_receiving
 
   cloudflare_zone   = cloudflare_zone.extraconlarp_org
   name              = "events.2021.extraconlarp.org"
-  verification_code = local.forwardemail_verification_records_by_domain["events.2021.extraconlarp.org"]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain["events.2021.extraconlarp.org"]
 }
 
 resource "cloudflare_dns_record" "extraconlarp_org_spf_record" {

--- a/forwardemail.tf
+++ b/forwardemail.tf
@@ -1,5 +1,5 @@
 module "forwardemail_receiving" {
-  source     = "github.com/neinteractiveliterature/intercode//terraform/modules/forwardemail_receiving?ref=cloudfront-og-shell"
+  source     = "github.com/neinteractiveliterature/intercode//terraform/modules/forwardemail_receiving?ref=main&depth=1"
   api_key    = var.forwardemail_api_key
   page_count = 2
 }

--- a/forwardemail.tf
+++ b/forwardemail.tf
@@ -1,25 +1,5 @@
-data "http" "forwardemail_domains" {
-  # increase this if we go past 100 domains
-  count = 2
-
-  url = "https://api.forwardemail.net/v1/domains?page=${count.index + 1}"
-
-  request_headers = {
-    Authorization = "Basic ${base64encode("${var.forwardemail_api_key}:")}"
-  }
-}
-
-locals {
-  forwardemail_domains_decoded = [for page in data.http.forwardemail_domains : jsondecode(page.body)]
-  forwardemail_domains         = toset(concat(local.forwardemail_domains_decoded...))
-
-  forwardemail_verification_records_by_domain_with_possible_dupes = {
-    for domain in local.forwardemail_domains :
-    domain["name"] => domain["verification_record"]...
-  }
-
-  forwardemail_verification_records_by_domain = {
-    for domain, records in local.forwardemail_verification_records_by_domain_with_possible_dupes :
-    domain => records[0]
-  }
+module "forwardemail_receiving" {
+  source     = "github.com/neinteractiveliterature/intercode//terraform/modules/forwardemail_receiving?ref=cloudfront-og-shell"
+  api_key    = var.forwardemail_api_key
+  page_count = 2
 }

--- a/interactiveliterature.org.tf
+++ b/interactiveliterature.org.tf
@@ -180,7 +180,7 @@ module "interactiveliterature_org_forwardemail_receiving_domain" {
 
   cloudflare_zone   = cloudflare_zone.interactiveliterature_org
   name              = "interactiveliterature.org"
-  verification_code = local.forwardemail_verification_records_by_domain["interactiveliterature.org"]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain["interactiveliterature.org"]
 }
 
 resource "cloudflare_dns_record" "interactiveliterature_org_acme_challenge_cname" {
@@ -214,25 +214,25 @@ resource "cloudflare_dns_record" "interactiveliterature_org_convention_subdomain
 module "interactiveliterature_org_convention_subdomain_forwardemail_receiving_domain" {
   source = "github.com/neinteractiveliterature/neil-terraform-modules//forwardemail_receiving_domain?ref=v1.0.0"
   for_each = setintersection(
-    keys(local.forwardemail_verification_records_by_domain),
+    keys(module.forwardemail_receiving.verification_records_by_domain),
     [for subdomain in local.interactiveliterature_org_intercode_subdomains : "${subdomain}.interactiveliterature.org"]
   )
 
   cloudflare_zone   = cloudflare_zone.interactiveliterature_org
   name              = each.value
-  verification_code = local.forwardemail_verification_records_by_domain[each.value]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain[each.value]
 }
 
 module "interactiveliterature_org_convention_subdomain_events_forwardemail_receiving_domain" {
   source = "github.com/neinteractiveliterature/neil-terraform-modules//forwardemail_receiving_domain?ref=v1.0.0"
   for_each = setintersection(
-    keys(local.forwardemail_verification_records_by_domain),
+    keys(module.forwardemail_receiving.verification_records_by_domain),
     [for subdomain in local.interactiveliterature_org_intercode_subdomains : "${subdomain}.events.interactiveliterature.org"]
   )
 
   cloudflare_zone   = each.value
   name              = "events.${each.value}"
-  verification_code = local.forwardemail_verification_records_by_domain[each.value]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain[each.value]
 }
 
 

--- a/intercode.tf
+++ b/intercode.tf
@@ -175,104 +175,86 @@ resource "rollbar_project_access_token" "intercode_post_server_item" {
   scopes     = ["post_server_item"]
 }
 
-resource "aws_sns_topic" "intercode_production_alarms" {
-  name = "intercode-production-alarms"
+module "intercode_aws_resources" {
+  source = "github.com/neinteractiveliterature/intercode//terraform/modules/intercode_aws_resources?ref=cloudfront-og-shell"
+
+  name                     = "intercode_production"
+  s3_bucket_name           = "intercode2-production"
+  alarm_email_destinations = local.intercode_production_alarm_email_destinations
 }
 
-resource "aws_sns_topic_subscription" "intercode_production_alarms_email_subscription" {
-  for_each = local.intercode_production_alarm_email_destinations
-
-  topic_arn = aws_sns_topic.intercode_production_alarms.arn
-  protocol  = "email"
-  endpoint  = each.value
+moved {
+  from = aws_sqs_queue.intercode_production_dead_letter
+  to   = module.intercode_aws_resources.aws_sqs_queue.dead_letter
 }
 
-# SQS queues used by Shoryuken for background processing
-resource "aws_sqs_queue" "intercode_production_dead_letter" {
-  name             = "intercode_production_dead_letter"
-  max_message_size = 1048576
+moved {
+  from = aws_sqs_queue.intercode_production_default
+  to   = module.intercode_aws_resources.aws_sqs_queue.default
 }
 
-resource "aws_sqs_queue" "intercode_production_default" {
-  name = "intercode_production_default"
-  redrive_policy = jsonencode(
-    {
-      deadLetterTargetArn = aws_sqs_queue.intercode_production_dead_letter.arn
-      maxReceiveCount     = 1
-    }
-  )
+moved {
+  from = aws_sqs_queue.intercode_production_mailers
+  to   = module.intercode_aws_resources.aws_sqs_queue.mailers
 }
 
-resource "aws_sqs_queue" "intercode_production_mailers" {
-  name = "intercode_production_mailers"
-  redrive_policy = jsonencode(
-    {
-      deadLetterTargetArn = aws_sqs_queue.intercode_production_dead_letter.arn
-      maxReceiveCount     = 1
-    }
-  )
+moved {
+  from = aws_sqs_queue.intercode_production_ahoy
+  to   = module.intercode_aws_resources.aws_sqs_queue.ahoy
 }
 
-resource "aws_sqs_queue" "intercode_production_ahoy" {
-  name = "intercode_production_ahoy"
-  redrive_policy = jsonencode(
-    {
-      deadLetterTargetArn = aws_sqs_queue.intercode_production_dead_letter.arn
-      maxReceiveCount     = 1
-    }
-  )
+moved {
+  from = aws_s3_bucket.intercode2_production
+  to   = module.intercode_aws_resources.aws_s3_bucket.uploads
 }
 
-resource "aws_cloudwatch_metric_alarm" "intercode_queue_backup" {
-  alarm_name          = "Intercode production queue backup"
-  alarm_description   = "Oldest message in Intercode production SQS queue is older than 5 minutes."
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 5
-  datapoints_to_alarm = 5
-  threshold           = 600
-
-  alarm_actions = [aws_sns_topic.intercode_production_alarms.arn]
-
-  metric_query {
-    id          = "q1"
-    label       = "Oldest message age in queue"
-    period      = 300
-    return_data = true
-    expression  = <<-EOT
-      SELECT MAX(ApproximateAgeOfOldestMessage)
-      FROM SCHEMA("AWS/SQS", QueueName)
-      WHERE QueueName != '${aws_sqs_queue.intercode_production_dead_letter.name}' AND QueueName != 'intercode_production_cloudwatch_scheduler-failures'
-    EOT
-  }
+moved {
+  from = aws_s3_bucket_acl.intercode2_production
+  to   = module.intercode_aws_resources.aws_s3_bucket_acl.uploads
 }
 
-# uploads.neilhosting.net, aka intercode2_production, is the Cloudfront-served S3 bucket we use
-# for uploaded CMS content and product images
-resource "aws_s3_bucket" "intercode2_production" {
-  bucket = "intercode2-production"
+moved {
+  from = aws_s3_bucket_cors_configuration.intercode2_production
+  to   = module.intercode_aws_resources.aws_s3_bucket_cors_configuration.uploads
 }
 
-resource "aws_s3_bucket_acl" "intercode2_production" {
-  bucket = aws_s3_bucket.intercode2_production.bucket
-  acl    = "private"
+# aws_sns_topic: name changes "intercode-production-alarms" → "intercode_production-alarms"
+# (ForceNew → recreated; alarm email subscribers will need to re-confirm)
+moved {
+  from = aws_sns_topic.intercode_production_alarms
+  to   = module.intercode_aws_resources.aws_sns_topic.alarms
 }
 
-resource "aws_s3_bucket_cors_configuration" "intercode2_production" {
-  bucket = aws_s3_bucket.intercode2_production.bucket
-
-  cors_rule {
-    allowed_headers = ["*"]
-    allowed_methods = ["GET", "PUT"]
-    allowed_origins = ["*"]
-    expose_headers = [
-      "Origin",
-      "Content-Type",
-      "Content-MD5",
-      "Content-Disposition"
-    ]
-    max_age_seconds = 3000
-  }
+# aws_cloudwatch_metric_alarm: alarm_name changes (ForceNew → recreated)
+moved {
+  from = aws_cloudwatch_metric_alarm.intercode_queue_backup
+  to   = module.intercode_aws_resources.aws_cloudwatch_metric_alarm.queue_backup
 }
+
+# IAM group/user/access key: names change from "intercode2-production" → "intercode_production"
+# (ForceNew → recreated; update app AWS credentials after applying)
+moved {
+  from = aws_iam_group.intercode2_production
+  to   = module.intercode_aws_resources.aws_iam_group.this
+}
+
+moved {
+  from = aws_iam_user.intercode2_production
+  to   = module.intercode_aws_resources.aws_iam_user.this
+}
+
+moved {
+  from = aws_iam_user_group_membership.intercode2_production
+  to   = module.intercode_aws_resources.aws_iam_user_group_membership.this
+}
+
+moved {
+  from = aws_iam_access_key.intercode2_production
+  to   = module.intercode_aws_resources.aws_iam_access_key.this
+}
+
+# aws_iam_group_policy.intercode2_production: replaced by two separate module policies
+# (intercode_aws_resources base policy + ses_email_receiving inbox policy)
 
 resource "cloudflare_dns_record" "uploads_neilhosting_net" {
   zone_id = cloudflare_zone.neilhosting_net.id
@@ -314,134 +296,6 @@ module "assets_neilhosting_net_cloudfront" {
   compress                 = true
 }
 
-
-# IAM policy so that Intercode can access the stuff it needs to access in AWS
-resource "aws_iam_group" "intercode2_production" {
-  name = "intercode2-production"
-}
-
-resource "aws_iam_group_policy" "intercode2_production" {
-  name  = "intercode2-production"
-  group = aws_iam_group.intercode2_production.name
-
-  policy = <<-EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "BackupFolderAccess",
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObjectVersion",
-        "s3:DeleteObjectVersion",
-        "s3:DeleteObject",
-        "s3:GetObject",
-        "s3:GetObjectAcl",
-        "s3:PutObject",
-        "s3:PutObjectAcl",
-        "s3:RestoreObject"
-      ],
-      "Resource": [
-        "${aws_s3_bucket.intercode2_production.arn}/*",
-        "${aws_s3_bucket.intercode_inbox.arn}/*"
-      ]
-    },
-    {
-      "Sid": "BucketLevelAccess",
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetBucketLocation",
-        "s3:ListAllMyBuckets",
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "arn:aws:s3:::*"
-      ]
-    },
-    {
-      "Sid": "ShoryukenAccess",
-      "Effect": "Allow",
-      "Action": [
-        "sqs:ChangeMessageVisibility",
-        "sqs:ChangeMessageVisibilityBatch",
-        "sqs:DeleteMessage",
-        "sqs:DeleteMessageBatch",
-        "sqs:GetQueueAttributes",
-        "sqs:GetQueueUrl",
-        "sqs:ReceiveMessage",
-        "sqs:SendMessage",
-        "sqs:SendMessageBatch",
-        "sqs:ListQueues"
-      ],
-      "Resource": "arn:aws:sqs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:intercode_production_*"
-    },
-    {
-      "Sid": "SesAccess",
-      "Effect":"Allow",
-      "Action":[
-        "ses:SendRawEmail",
-        "ses:SendBounce"
-      ],
-      "Resource":"*"
-    },
-    {
-      "Sid": "SnsAccess",
-      "Effect":"Allow",
-      "Action":[
-        "sns:ConfirmSubscription"
-      ],
-      "Resource": "${aws_sns_topic.intercode_inbox_deliveries.arn}"
-    },
-    {
-      "Sid": "KmsAccess",
-      "Effect": "Allow",
-      "Action": "kms:Decrypt",
-      "Resource": "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/2570e363-9e0e-4a1a-b4de-41c2460786df"
-    },
-    {
-      "Sid": "CloudwatchSchedulerProvisioning",
-      "Effect": "Allow",
-      "Action": [
-        "sqs:CreateQueue",
-        "sqs:GetQueueAttributes",
-        "sqs:SetQueueAttributes"
-      ],
-      "Resource": [
-        "arn:aws:sqs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:intercode_production_cloudwatch_scheduler",
-        "arn:aws:sqs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:intercode_production_cloudwatch_scheduler-failures"
-      ]
-    },
-    {
-      "Sid": "CloudwatchSchedulerAccess",
-      "Effect": "Allow",
-      "Action": [
-        "events:PutRule",
-        "events:PutTargets"
-      ],
-      "Resource": [
-        "*"
-      ]
-    }
-  ]
-}
-  EOF
-
-  # TODO: I can't figure out a good way to avoid hardcoding the key ID in KmsAccess, maybe figure
-  # it out later
-}
-
-resource "aws_iam_user" "intercode2_production" {
-  name = "intercode2-production"
-}
-
-resource "aws_iam_user_group_membership" "intercode2_production" {
-  user   = aws_iam_user.intercode2_production.name
-  groups = [aws_iam_group.intercode2_production.name]
-}
-
-resource "aws_iam_access_key" "intercode2_production" {
-  user = aws_iam_user.intercode2_production.name
-}
 
 resource "github_repository" "intercode" {
   name        = "intercode"

--- a/intercode.tf
+++ b/intercode.tf
@@ -176,7 +176,7 @@ resource "rollbar_project_access_token" "intercode_post_server_item" {
 }
 
 module "intercode_aws_resources" {
-  source = "github.com/neinteractiveliterature/intercode//terraform/modules/intercode_aws_resources?ref=cloudfront-og-shell"
+  source = "github.com/neinteractiveliterature/intercode//terraform/modules/intercode_aws_resources?ref=main&depth=1"
 
   name                     = "intercode_production"
   s3_bucket_name           = "intercode2-production"

--- a/interconlarp.org.tf
+++ b/interconlarp.org.tf
@@ -154,7 +154,7 @@ module "interconlarp_org_forwardemail_receiving_domain" {
 
   cloudflare_zone   = cloudflare_zone.interconlarp_org
   name              = "interconlarp.org"
-  verification_code = local.forwardemail_verification_records_by_domain["interconlarp.org"]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain["interconlarp.org"]
 }
 
 resource "cloudflare_dns_record" "interconlarp_org_acme_challenge_cname" {
@@ -191,7 +191,7 @@ module "interconlarp_org_convention_subdomain_forwardemail_receiving_domain" {
 
   cloudflare_zone   = cloudflare_zone.interconlarp_org
   name              = each.value
-  verification_code = local.forwardemail_verification_records_by_domain[each.value]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain[each.value]
 }
 
 module "interconlarp_org_forward_only_subdomain_forwardemail_receiving_domain" {
@@ -200,19 +200,19 @@ module "interconlarp_org_forward_only_subdomain_forwardemail_receiving_domain" {
 
   cloudflare_zone   = cloudflare_zone.interconlarp_org
   name              = each.value
-  verification_code = local.forwardemail_verification_records_by_domain[each.value]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain[each.value]
 }
 
 module "interconlarp_org_convention_subdomain_events_forwardemail_receiving_domain" {
   for_each = setintersection(
-    keys(local.forwardemail_verification_records_by_domain),
+    keys(module.forwardemail_receiving.verification_records_by_domain),
     [for subdomain in local.interconlarp_org_intercode_subdomains : "events.${subdomain}.interconlarp.org"]
   )
   source = "github.com/neinteractiveliterature/neil-terraform-modules//forwardemail_receiving_domain?ref=v1.0.0"
 
   cloudflare_zone   = cloudflare_zone.interconlarp_org
   name              = each.value
-  verification_code = local.forwardemail_verification_records_by_domain[each.value]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain[each.value]
 }
 
 resource "cloudflare_dns_record" "interconlarp_org_www_cname" {

--- a/interconlarp.org.tf
+++ b/interconlarp.org.tf
@@ -6,7 +6,7 @@ locals {
     "f",
     "g",
     "h",
-    "i",
+    # "i" is served via its own cloudfront_intercode distribution
     "j",
     "k",
     "l",
@@ -260,5 +260,71 @@ resource "cloudflare_dns_record" "interconlarp_org_security_forwarder_cname" {
   name    = "security-forwarder.interconlarp.org"
   type    = "CNAME"
   content = "intercon-security-forwarder.fly.dev"
+  ttl     = 1
+}
+
+# ---------------------------------------------------------------------------
+# i.interconlarp.org — served via cloudfront_intercode (OG shell + SPA shell)
+# ---------------------------------------------------------------------------
+
+resource "aws_acm_certificate" "i_interconlarp_org" {
+  domain_name       = "i.interconlarp.org"
+  validation_method = "DNS"
+}
+
+resource "cloudflare_dns_record" "i_interconlarp_org_acm_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.i_interconlarp_org.domain_validation_options : dvo.domain_name => {
+      name  = trimsuffix(dvo.resource_record_name, ".")
+      type  = dvo.resource_record_type
+      value = trimsuffix(dvo.resource_record_value, ".")
+    }
+  }
+
+  zone_id = cloudflare_zone.interconlarp_org.id
+  name    = each.value.name
+  type    = each.value.type
+  content = each.value.value
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "i_interconlarp_org" {
+  certificate_arn         = aws_acm_certificate.i_interconlarp_org.arn
+  validation_record_fqdns = [for dvo in aws_acm_certificate.i_interconlarp_org.domain_validation_options : trimsuffix(dvo.resource_record_name, ".")]
+}
+
+module "i_interconlarp_org_cloudfront" {
+  source = "github.com/neinteractiveliterature/intercode//terraform/modules/cloudfront_intercode?ref=main&depth=1"
+
+  providers = {
+    aws           = aws
+    aws.us_east_1 = aws.us_east_1
+  }
+
+  name                 = "i-interconlarp-org"
+  rails_origin_domain  = "www.neilhosting.net"
+  assets_origin_domain = "assets.neilhosting.net"
+  aliases              = ["i.interconlarp.org"]
+  acm_certificate_arn  = aws_acm_certificate_validation.i_interconlarp_org.certificate_arn
+}
+
+module "i_interconlarp_org_forwardemail_receiving_domain" {
+  source = "github.com/neinteractiveliterature/neil-terraform-modules//forwardemail_receiving_domain?ref=v1.0.0"
+
+  cloudflare_zone   = cloudflare_zone.interconlarp_org
+  name              = "i.interconlarp.org"
+  verification_code = module.forwardemail_receiving.verification_records_by_domain["i.interconlarp.org"]
+}
+
+moved {
+  from = module.interconlarp_org_convention_subdomain_forwardemail_receiving_domain["i.interconlarp.org"]
+  to   = module.i_interconlarp_org_forwardemail_receiving_domain
+}
+
+resource "cloudflare_dns_record" "i_interconlarp_org_cname" {
+  zone_id = cloudflare_zone.interconlarp_org.id
+  name    = "i.interconlarp.org"
+  type    = "CNAME"
+  content = module.i_interconlarp_org_cloudfront.distribution_domain_name
   ttl     = 1
 }

--- a/larp_library.tf
+++ b/larp_library.tf
@@ -225,7 +225,7 @@ module "larplibrary_org_forwardemail_receiving_domain" {
 
   cloudflare_zone   = cloudflare_zone.larplibrary_org
   name              = "larplibrary.org"
-  verification_code = local.forwardemail_verification_records_by_domain["larplibrary.org"]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain["larplibrary.org"]
 }
 
 resource "cloudflare_dns_record" "assets_larplibrary_org" {

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,13 @@ provider "aws" {
   profile = var.aws_profile
 }
 
+# Explicit us-east-1 alias required by modules that deploy Lambda@Edge
+provider "aws" {
+  alias   = "us_east_1"
+  region  = "us-east-1"
+  profile = var.aws_profile
+}
+
 # provider "heroku" {
 # }
 

--- a/neil_production_db.tf
+++ b/neil_production_db.tf
@@ -117,7 +117,7 @@ resource "aws_cloudwatch_metric_alarm" "neil_production_low_disk_space" {
   datapoints_to_alarm = 5
   threshold           = 5 * 1024 * 1024 * 1024
 
-  alarm_actions = [aws_sns_topic.intercode_production_alarms.arn]
+  alarm_actions = [module.intercode_aws_resources.alarm_sns_topic_arn]
 
   namespace   = "AWS/RDS"
   metric_name = "FreeStorageSpace"
@@ -133,7 +133,7 @@ resource "aws_cloudwatch_metric_alarm" "neil_production_high_read_latency" {
   datapoints_to_alarm = 2
   threshold           = 0.1
 
-  alarm_actions = [aws_sns_topic.intercode_production_alarms.arn]
+  alarm_actions = [module.intercode_aws_resources.alarm_sns_topic_arn]
 
   metric_query {
     id          = "q1"

--- a/neilhosting.net.tf
+++ b/neilhosting.net.tf
@@ -55,7 +55,7 @@ module "neilhosting_net_forwardemail_receiving_domain" {
 
   cloudflare_zone   = cloudflare_zone.neilhosting_net
   name              = "neilhosting.net"
-  verification_code = local.forwardemail_verification_records_by_domain["neilhosting.net"]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain["neilhosting.net"]
 }
 
 module "neilhosting_net_intercode_subdomain_forwardemail_receiving_domain" {
@@ -64,7 +64,7 @@ module "neilhosting_net_intercode_subdomain_forwardemail_receiving_domain" {
 
   cloudflare_zone   = cloudflare_zone.neilhosting_net
   name              = each.value
-  verification_code = local.forwardemail_verification_records_by_domain[each.value]
+  verification_code = module.forwardemail_receiving.verification_records_by_domain[each.value]
 }
 
 resource "cloudflare_dns_record" "neilhosting_net_spf" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,10 @@
+output "intercode_aws_access_key_id" {
+  description = "AWS access key ID for the Intercode production IAM user."
+  value       = module.intercode_aws_resources.iam_access_key_id
+}
+
+output "intercode_aws_secret_access_key" {
+  description = "AWS secret access key for the Intercode production IAM user."
+  value       = module.intercode_aws_resources.iam_access_key_secret
+  sensitive   = true
+}

--- a/ses-receiving.tf
+++ b/ses-receiving.tf
@@ -1,5 +1,5 @@
 module "intercode_ses_email_receiving" {
-  source = "github.com/neinteractiveliterature/intercode//terraform/modules/ses_email_receiving?ref=cloudfront-og-shell"
+  source = "github.com/neinteractiveliterature/intercode//terraform/modules/ses_email_receiving?ref=main&depth=1"
 
   name                      = "intercode"
   inbox_bucket_name         = "intercode-inbox"

--- a/ses-receiving.tf
+++ b/ses-receiving.tf
@@ -1,195 +1,68 @@
-resource "aws_s3_bucket" "intercode_inbox" {
-  bucket = "intercode-inbox"
+module "intercode_ses_email_receiving" {
+  source = "github.com/neinteractiveliterature/intercode//terraform/modules/ses_email_receiving?ref=cloudfront-og-shell"
+
+  name                      = "intercode"
+  inbox_bucket_name         = "intercode-inbox"
+  sns_notification_endpoint = "https://www.neilhosting.net/sns_notifications"
+  iam_group_name            = module.intercode_aws_resources.iam_group_name
 }
 
-resource "aws_s3_bucket_policy" "intercode_inbox" {
-  bucket = aws_s3_bucket.intercode_inbox.bucket
-  policy = <<EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Sid": "AllowSESPuts",
-        "Effect": "Allow",
-        "Principal": {
-          "Service": "ses.amazonaws.com"
-        },
-        "Action": "s3:PutObject",
-        "Resource": "arn:aws:s3:::intercode-inbox/*",
-        "Condition": {
-          "StringEquals": {
-            "aws:Referer": "${data.aws_caller_identity.current.account_id}"
-          }
-        }
-      }
-    ]
-  }
-  EOF
+moved {
+  from = aws_s3_bucket.intercode_inbox
+  to   = module.intercode_ses_email_receiving.aws_s3_bucket.inbox
 }
 
-resource "aws_s3_bucket_acl" "intercode_inbox" {
-  bucket = aws_s3_bucket.intercode_inbox.bucket
-  acl    = "private"
+moved {
+  from = aws_s3_bucket_acl.intercode_inbox
+  to   = module.intercode_ses_email_receiving.aws_s3_bucket_acl.inbox
 }
 
-resource "aws_s3_bucket_lifecycle_configuration" "intercode_inbox" {
-  bucket = aws_s3_bucket.intercode_inbox.bucket
-  rule {
-    id     = "message_expiration"
-    status = "Enabled"
-    expiration {
-      days = 14
-    }
-  }
+moved {
+  from = aws_s3_bucket_policy.intercode_inbox
+  to   = module.intercode_ses_email_receiving.aws_s3_bucket_policy.inbox
 }
 
-resource "aws_iam_role" "sns_success_feedback" {
-  assume_role_policy = jsonencode(
-    {
-      Statement = [
-        {
-          Action = "sts:AssumeRole"
-          Effect = "Allow"
-          Principal = {
-            Service = "sns.amazonaws.com"
-          }
-        },
-      ]
-      Version = "2012-10-17"
-    }
-  )
+moved {
+  from = aws_s3_bucket_lifecycle_configuration.intercode_inbox
+  to   = module.intercode_ses_email_receiving.aws_s3_bucket_lifecycle_configuration.inbox
 }
 
-resource "aws_iam_role_policy" "sns_success_feedback" {
-  name = "oneClick_SNSSuccessFeedback_1584129549314"
-  role = aws_iam_role.sns_success_feedback.name
-  policy = jsonencode(
-    {
-      Statement = [
-        {
-          Action = [
-            "logs:CreateLogGroup",
-            "logs:CreateLogStream",
-            "logs:PutLogEvents",
-            "logs:PutMetricFilter",
-            "logs:PutRetentionPolicy",
-          ]
-          Effect = "Allow"
-          Resource = [
-            "*",
-          ]
-        },
-      ]
-      Version = "2012-10-17"
-    }
-  )
+moved {
+  from = aws_sns_topic.intercode_inbox_deliveries
+  to   = module.intercode_ses_email_receiving.aws_sns_topic.inbox_deliveries
 }
 
-resource "aws_iam_role" "sns_failure_feedback" {
-  assume_role_policy = jsonencode(
-    {
-      Statement = [
-        {
-          Action = "sts:AssumeRole"
-          Effect = "Allow"
-          Principal = {
-            Service = "sns.amazonaws.com"
-          }
-        },
-      ]
-      Version = "2012-10-17"
-    }
-  )
+moved {
+  from = aws_sns_topic_subscription.intercode_inbox_deliveries_webhook
+  to   = module.intercode_ses_email_receiving.aws_sns_topic_subscription.inbox_deliveries_webhook
 }
 
-resource "aws_iam_role_policy" "sns_failure_feedback" {
-  name = "oneClick_SNSFailureFeedback_1584129549315"
-  role = aws_iam_role.sns_failure_feedback.name
-  policy = jsonencode(
-    {
-      Statement = [
-        {
-          Action = [
-            "logs:CreateLogGroup",
-            "logs:CreateLogStream",
-            "logs:PutLogEvents",
-            "logs:PutMetricFilter",
-            "logs:PutRetentionPolicy",
-          ]
-          Effect = "Allow"
-          Resource = [
-            "*",
-          ]
-        },
-      ]
-      Version = "2012-10-17"
-    }
-  )
+moved {
+  from = aws_ses_receipt_rule_set.intercode_inbox
+  to   = module.intercode_ses_email_receiving.aws_ses_receipt_rule_set.inbox
 }
 
-resource "aws_sns_topic" "intercode_inbox_deliveries" {
-  name                           = "intercode-inbox-deliveries"
-  http_success_feedback_role_arn = aws_iam_role.sns_success_feedback.arn
-  http_failure_feedback_role_arn = aws_iam_role.sns_failure_feedback.arn
+moved {
+  from = aws_ses_active_receipt_rule_set.active_rule_set
+  to   = module.intercode_ses_email_receiving.aws_ses_active_receipt_rule_set.inbox
 }
 
-resource "aws_sns_topic_subscription" "intercode_inbox_deliveries_webhook" {
-  topic_arn              = aws_sns_topic.intercode_inbox_deliveries.arn
-  protocol               = "https"
-  endpoint               = "https://www.neilhosting.net/sns_notifications"
-  endpoint_auto_confirms = true
-
-  delivery_policy = jsonencode({
-    guaranteed = false
-    healthyRetryPolicy = {
-      backoffFunction    = "linear"
-      maxDelayTarget     = 300
-      minDelayTarget     = 20
-      numMaxDelayRetries = 0
-      numMinDelayRetries = 0
-      numNoDelayRetries  = 0
-      numRetries         = 3
-    }
-    sicklyRetryPolicy = null
-    throttlePolicy    = null
-  })
+moved {
+  from = aws_ses_receipt_rule.store_and_notify
+  to   = module.intercode_ses_email_receiving.aws_ses_receipt_rule.store_and_notify
 }
 
-resource "aws_ses_receipt_rule_set" "intercode_inbox" {
-  rule_set_name = "intercode-inbox"
+# aws_ses_configuration_set.default: name changes "default" → "intercode-default" (ForceNew
+# → will be destroyed and recreated; update DEFAULT_CONFIGURATION_SET in the app accordingly)
+moved {
+  from = aws_ses_configuration_set.default
+  to   = module.intercode_ses_email_receiving.aws_ses_configuration_set.default
 }
 
-resource "aws_ses_active_receipt_rule_set" "active_rule_set" {
-  rule_set_name = aws_ses_receipt_rule_set.intercode_inbox.rule_set_name
+moved {
+  from = aws_ses_event_destination.cloudwatch
+  to   = module.intercode_ses_email_receiving.aws_ses_event_destination.cloudwatch
 }
 
-resource "aws_ses_receipt_rule" "store_and_notify" {
-  name          = "store_and_notify"
-  rule_set_name = aws_ses_receipt_rule_set.intercode_inbox.rule_set_name
-  enabled       = true
-  scan_enabled  = true
-
-  s3_action {
-    bucket_name = aws_s3_bucket.intercode_inbox.bucket
-    position    = 1
-    kms_key_arn = "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:alias/aws/ses"
-    topic_arn   = aws_sns_topic.intercode_inbox_deliveries.arn
-  }
-}
-
-resource "aws_ses_configuration_set" "default" {
-  name = "default"
-}
-
-resource "aws_ses_event_destination" "cloudwatch" {
-  name                   = "ses-sends"
-  configuration_set_name = aws_ses_configuration_set.default.name
-  enabled                = true
-  matching_types         = ["bounce", "complaint", "delivery", "reject", "send"]
-
-  cloudwatch_destination {
-    default_value  = aws_ses_configuration_set.default.name
-    dimension_name = "ses:configuration-set"
-    value_source   = "messageTag"
-  }
-}
+# aws_iam_role.sns_success_feedback / sns_failure_feedback had auto-generated names; the
+# module assigns explicit names so these will be recreated with no functional impact.


### PR DESCRIPTION
### Purpose

The Intercode repo now vends reusable Terraform modules on its `cloudfront-og-shell` branch, and a bunch of our inline AWS infrastructure is a direct match. This PR wires us up to those modules to reduce duplication and keep the two repos in sync going forward.

Three modules are adopted here:

- **`intercode_aws_resources`** — replaces the inline SQS queues, uploads S3 bucket, SNS alarms topic, CloudWatch queue-backup alarm, and IAM group/user/access key/policy. As a nice side effect, this also resolves the long-standing `TODO` about the hardcoded KMS key ARN — the module uses `alias/aws/ses` instead.
- **`ses_email_receiving`** — replaces all of `ses-receiving.tf`: inbox S3 bucket, SES receipt rules, SNS delivery topic and subscription, and the IAM policies for inbox access. The inbox-related IAM permissions are now a separate group policy rather than bundled into the giant inline policy.
- **`forwardemail_receiving`** — replaces the inline `data "http"` sources and deduplication locals in `forwardemail.tf`.

`moved {}` blocks preserve state for the resources that just change Terraform address (SQS queues, S3 buckets, SES receipt rules, etc.) so they won't be destroyed and recreated. A handful of resources will be replaced due to ForceNew name changes — see the comments in the diff for details on what follow-up is needed after apply (mainly: re-confirm alarm email subscriptions, update `DEFAULT_CONFIGURATION_SET` in the app, and swap in the new IAM credentials).

An `outputs.tf` was added to surface the new IAM access key ID and secret after apply.

### Risks

All module sources currently point at `?ref=cloudfront-og-shell`. Once that branch merges and gets tagged, the refs should be updated to a stable tag.

🚢

🤖 Generated with [Claude Code](https://claude.com/claude-code)